### PR TITLE
Improve responsive menu and portfolio titles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -120,6 +120,13 @@ header nav ul li a {
     justify-content: space-between;
 }
 
+.menu-toggle {
+    display: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #FEFDFF;
+}
+
 .intro-background {
     background-image: url("../../img/background/backgroundHeader.jpg");
     background-size: cover; /* Assure que l'image couvre entièrement la div */
@@ -393,10 +400,12 @@ span {
     left: 50%;
     transform: translate(-50%, -50%);
     color: white;
-    font-family: 'Montserrat', sans-serif; /* Appliquez la police Montserrat */
-    font-size: 1.2vw; /* Ajustez la taille de la police selon vos préférences */
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(14px, 2.5vw, 22px);
     text-align: center;
-    white-space: nowrap; /* Empêche le texte de se diviser en plusieurs lignes */
+    white-space: normal;
+    width: 90%;
+    line-height: 1.2;
     font-weight: bold;
     text-shadow:
     0 0 6px rgba(0, 0, 0, 0.7),
@@ -585,10 +594,19 @@ span {
         gap: 10px;
     }
 
+    .menu-toggle {
+        display: block;
+    }
+
     header nav ul {
+        display: none;
         flex-direction: column;
         align-items: center;
-        width: auto;
+        width: 100%;
+    }
+
+    header nav ul.show-menu {
+        display: flex;
     }
 
     #headerTitle {

--- a/de/index.html
+++ b/de/index.html
@@ -14,6 +14,7 @@
         <nav>
             <a href="index.html"><img src="../img/logo/logoAlpha.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="#about" id="navAbout">Über uns</a></li>
                 <li><a href="#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/de/js/jsIndex.js
+++ b/de/js/jsIndex.js
@@ -32,3 +32,16 @@ function handleClickOutside(event) {
 
 // Ajoute l'écouteur d'événements au document pour détecter les clics à l'extérieur
 document.addEventListener('click', handleClickOutside);
+
+// Toggle navigation menu on small screens
+document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('menuToggle');
+    if (toggle) {
+        toggle.addEventListener('click', function () {
+            var navList = document.querySelector('header nav ul');
+            if (navList) {
+                navList.classList.toggle('show-menu');
+            }
+        });
+    }
+});

--- a/de/portfolio/smartvitale/js_script.js
+++ b/de/portfolio/smartvitale/js_script.js
@@ -32,3 +32,16 @@ function handleClickOutside(event) {
 
 // Ajoute l'écouteur d'événements au document pour détecter les clics à l'extérieur
 document.addEventListener('click', handleClickOutside);
+
+// Toggle navigation menu on small screens
+document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('menuToggle');
+    if (toggle) {
+        toggle.addEventListener('click', function () {
+            var navList = document.querySelector('header nav ul');
+            if (navList) {
+                navList.classList.toggle('show-menu');
+            }
+        });
+    }
+});

--- a/de/portfolio/smartvitale/smartvitale.html
+++ b/de/portfolio/smartvitale/smartvitale.html
@@ -14,6 +14,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlpha.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/de/portfolio/tipe/tipe.html
+++ b/de/portfolio/tipe/tipe.html
@@ -14,6 +14,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlpha.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/es/index.html
+++ b/es/index.html
@@ -12,6 +12,7 @@
         <nav>
             <a href="index.html"><img src="../img/logo/logoAlpha.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="#about" id="navAbout">À propos</a></li>
                 <li><a href="#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/index.html
+++ b/fr/index.html
@@ -24,6 +24,7 @@
         <nav>
             <a href="index.html"><img src="../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="#about" id="navAbout">À propos</a></li>
                 <li><a href="#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/capteur-beton.html
+++ b/fr/portfolio/capteur-beton.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="/fr/index.html"><img src="/img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/capteur-capacitif.html
+++ b/fr/portfolio/capteur-capacitif.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="/img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/chaussures-connectees.html
+++ b/fr/portfolio/chaussures-connectees.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/ecoulement_air.html
+++ b/fr/portfolio/ecoulement_air.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/electrodes-ecg.html
+++ b/fr/portfolio/electrodes-ecg.html
@@ -26,6 +26,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/essai-ia-ethique.html
+++ b/fr/portfolio/essai-ia-ethique.html
@@ -33,6 +33,7 @@
         <nav>
             <a href="/fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/higgsboson.html
+++ b/fr/portfolio/higgsboson.html
@@ -24,6 +24,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/js_script.js
+++ b/fr/portfolio/js_script.js
@@ -32,3 +32,16 @@ function handleClickOutside(event) {
 
 // Ajoute l'écouteur d'événements au document pour détecter les clics à l'extérieur
 document.addEventListener('click', handleClickOutside);
+
+// Toggle navigation menu on small screens
+document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('menuToggle');
+    if (toggle) {
+        toggle.addEventListener('click', function () {
+            var navList = document.querySelector('header nav ul');
+            if (navList) {
+                navList.classList.toggle('show-menu');
+            }
+        });
+    }
+});

--- a/fr/portfolio/matrice-oled.html
+++ b/fr/portfolio/matrice-oled.html
@@ -26,6 +26,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/propagationIonospherique.html
+++ b/fr/portfolio/propagationIonospherique.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/reconnaissance-chiffres.html
+++ b/fr/portfolio/reconnaissance-chiffres.html
@@ -26,6 +26,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/riscv_processor.html
+++ b/fr/portfolio/riscv_processor.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/smartvitale.html
+++ b/fr/portfolio/smartvitale.html
@@ -24,6 +24,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/fr/portfolio/tipe.html
+++ b/fr/portfolio/tipe.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">À propos</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="index.html"><img src="../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="#about" id="navAbout">About</a></li>
                 <li><a href="#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/js/jsIndex.js
+++ b/js/jsIndex.js
@@ -32,3 +32,16 @@ function handleClickOutside(event) {
 
 // Ajoute l'écouteur d'événements au document pour détecter les clics à l'extérieur
 document.addEventListener('click', handleClickOutside);
+
+// Toggle navigation menu on small screens
+document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('menuToggle');
+    if (toggle) {
+        toggle.addEventListener('click', function () {
+            var navList = document.querySelector('header nav ul');
+            if (navList) {
+                navList.classList.toggle('show-menu');
+            }
+        });
+    }
+});

--- a/portfolio/capacitive-sensor.html
+++ b/portfolio/capacitive-sensor.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/concrete-sensor.html
+++ b/portfolio/concrete-sensor.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/deeplearning.html
+++ b/portfolio/deeplearning.html
@@ -24,6 +24,7 @@
         <nav>
             <a href="/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/ecg-design.html
+++ b/portfolio/ecg-design.html
@@ -26,6 +26,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/ethical-ai-essay.html
+++ b/portfolio/ethical-ai-essay.html
@@ -33,6 +33,7 @@
         <nav>
             <a href="/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/higgsboson.html
+++ b/portfolio/higgsboson.html
@@ -24,6 +24,7 @@
         <nav>
             <a href="../../index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/ionospheric-propagation.html
+++ b/portfolio/ionospheric-propagation.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="../index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/js_script.js
+++ b/portfolio/js_script.js
@@ -32,3 +32,16 @@ function handleClickOutside(event) {
 
 // Ajoute l'écouteur d'événements au document pour détecter les clics à l'extérieur
 document.addEventListener('click', handleClickOutside);
+
+// Toggle navigation menu on small screens
+document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('menuToggle');
+    if (toggle) {
+        toggle.addEventListener('click', function () {
+            var navList = document.querySelector('header nav ul');
+            if (navList) {
+                navList.classList.toggle('show-menu');
+            }
+        });
+    }
+});

--- a/portfolio/oled-matrix.html
+++ b/portfolio/oled-matrix.html
@@ -26,6 +26,7 @@
         <nav>
             <a href="../../../fr/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/fr/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/fr/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/smartvitale.html
+++ b/portfolio/smartvitale.html
@@ -24,6 +24,7 @@
         <nav>
             <a href="../../index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/index.html#portfolio" id="navPortfolio">Portfolio</a></li>

--- a/portfolio/tipe.html
+++ b/portfolio/tipe.html
@@ -25,6 +25,7 @@
         <nav>
             <a href="/index.html"><img src="../../../img/logo/logoAlphaWhite.png" alt="Website Logo" id="siteLogo"></a>
             <div id="headerTitle">Paul Guillemin</div>
+            <div id="menuToggle" class="menu-toggle">&#9776;</div>
             <ul>
                 <li><a href="/index.html#about" id="navAbout">About</a></li>
                 <li><a href="/index.html#portfolio" id="navPortfolio">Portfolio</a></li>


### PR DESCRIPTION
## Summary
- added hamburger icon markup across portfolio pages
- allow portfolio item titles to wrap and span full item width
- implemented mobile menu toggle logic in JS
- updated responsive CSS for navigation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685153dd45308322aad21fb8c3e1374b