### PR TITLE
Fix language codes for German, Spanish, and English pages

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="de">
 <head>
     <meta charset="UTF-8">
     <title>Paul Guillemin</title>

--- a/de/portfolio/smartvitale/smartvitale.html
+++ b/de/portfolio/smartvitale/smartvitale.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="de">
 <head>
     <meta charset="UTF-8">
     <title>Paul Guillemin</title>

--- a/de/portfolio/tipe/tipe.html
+++ b/de/portfolio/tipe/tipe.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="de">
 <head>
     <meta charset="UTF-8">
     <title>Paul Guillemin</title>

--- a/es/index.html
+++ b/es/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <title>Paul Guillemin</title>

--- a/portfolio/ecg-design.html
+++ b/portfolio/ecg-design.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFDESVG1RX"></script>

--- a/portfolio/ethical-ai-essay.html
+++ b/portfolio/ethical-ai-essay.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFDESVG1RX"></script>

--- a/portfolio/higgsboson.html
+++ b/portfolio/higgsboson.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFDESVG1RX"></script>

--- a/portfolio/ionospheric-propagation.html
+++ b/portfolio/ionospheric-propagation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFDESVG1RX"></script>

--- a/portfolio/oled-matrix.html
+++ b/portfolio/oled-matrix.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFDESVG1RX"></script>

--- a/portfolio/smartvitale.html
+++ b/portfolio/smartvitale.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFDESVG1RX"></script>


### PR DESCRIPTION
## Summary
- correct `lang` attribute for German and Spanish home pages
- fix language codes on German portfolio pages
- update language codes on English articles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687e0982949c8322a54955db7e6170cd