### PR TITLE
Improve mobile view for portfolio articles

### DIFF
--- a/fr/portfolio/capteur-beton.html
+++ b/fr/portfolio/capteur-beton.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Capteur béton</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/capteur-capacitif.html
+++ b/fr/portfolio/capteur-capacitif.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/chaussures-connectees.html
+++ b/fr/portfolio/chaussures-connectees.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/ecoulement_air.html
+++ b/fr/portfolio/ecoulement_air.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/electrodes-ecg.html
+++ b/fr/portfolio/electrodes-ecg.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/essai-ia-ethique.html
+++ b/fr/portfolio/essai-ia-ethique.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/higgsboson.html
+++ b/fr/portfolio/higgsboson.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/matrice-oled.html
+++ b/fr/portfolio/matrice-oled.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/propagationIonospherique.html
+++ b/fr/portfolio/propagationIonospherique.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin - Propagation ionosphérique</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/reconnaissance-chiffres.html
+++ b/fr/portfolio/reconnaissance-chiffres.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/riscv_processor.html
+++ b/fr/portfolio/riscv_processor.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/smartvitale.html
+++ b/fr/portfolio/smartvitale.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/fr/portfolio/style.css
+++ b/fr/portfolio/style.css
@@ -310,12 +310,12 @@ p {
 }
 
 .presentation {
-    margin: 180px;
+    margin: 180px auto;
 }
 
 @media (max-width: 600px) {
     .presentation {
-        margin: 20px;
+        margin: 20px auto;
     }
 }
 

--- a/fr/portfolio/tipe.html
+++ b/fr/portfolio/tipe.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/concrete-sensor.html
+++ b/portfolio/concrete-sensor.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Concrete Sensor - Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/deeplearning.html
+++ b/portfolio/deeplearning.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/ecg-design.html
+++ b/portfolio/ecg-design.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ECG Design - Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/ethical-ai-essay.html
+++ b/portfolio/ethical-ai-essay.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/higgsboson.html
+++ b/portfolio/higgsboson.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin - Exploring the Higgs Boson</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/ionospheric-propagation.html
+++ b/portfolio/ionospheric-propagation.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin - Wave propagation</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/oled-matrix.html
+++ b/portfolio/oled-matrix.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OLEDs Matrix - Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/smartvitale.html
+++ b/portfolio/smartvitale.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">

--- a/portfolio/style.css
+++ b/portfolio/style.css
@@ -305,12 +305,12 @@ p {
 }
 
 .presentation {
-    margin: 180px;
+    margin: 180px auto;
 }
 
 @media (max-width: 600px) {
     .presentation {
-        margin: 20px;
+        margin: 20px auto;
     }
 }
 

--- a/portfolio/tipe.html
+++ b/portfolio/tipe.html
@@ -11,6 +11,7 @@
   gtag('config', 'G-LFDESVG1RX');
 </script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paul Guillemin</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
## Summary
- add viewport meta tag to all portfolio article pages (EN and FR)
- center article content by using automatic horizontal margins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e5bbedcf08322b58f315ce0099ddf